### PR TITLE
fix-修复Popover 文档演示BUG

### DIFF
--- a/packages/react-popover/README.md
+++ b/packages/react-popover/README.md
@@ -82,7 +82,9 @@ class Demo extends React.Component {
               </Card>
             }
           >
-            <Icon type="setting" color="#343a40" style={{ fontSize: 20 }} />
+            <div>
+              <Icon type="setting" color="#343a40" style={{ fontSize: 20 }} />
+            </div>
           </Popover>
         </div>
       </Row>


### PR DESCRIPTION
修复Popover 文档演示BUG，使用将`Icon`组件放置`div`标签中